### PR TITLE
Use HTML source if block.config.src is empty

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -20,7 +20,7 @@ var findNotIn = function (obj, other) {
  * entire block may be removed.
  *
  * @constructor
- * 
+ *
  * @param{string}           name            - The name of the block.
  * @param {BlockConfig}     config          - The block configuration.
  *
@@ -48,10 +48,11 @@ var Block = module.exports = function (name, config) {
 /**
  * Finds new files for the block using the matching patterns in the configuration.
  * Files that were already in the file but are not found now are removed.
- * Files that aren't already in the block are added at the end of the files array. 
+ * Files that aren't already in the block are added at the end of the files array.
  */
 Block.prototype.updateFiles = function () {
-    var maps = grunt.file.expandMapping(this.config.src, this.config.prefix, this.config);
+		var srcFiles = this.config.src.length ? this.config.src : this.files;
+    var maps = grunt.file.expandMapping(srcFiles, this.config.prefix, this.config);
     var files = _.flatten(maps, 'dest');
 
     var previousIdx = _.object(this.files, _.range(this.files.length));


### PR DESCRIPTION
I wanted the ability to do this: 

```
[D] Source file before processing.
[D]       <!-- fileblock:other reload -->
      <script src="//localhost:35729/livereload.js"></script>
      <!-- endfileblock -->

      <!-- build:js /assets/js/app.js -->
      <!-- fileblock:js scripts -->
      <script src="assets/js/libs/a.lib.js"></script>
      <script src="assets/js/libs/b.lib.js"></script>
      <script src="assets/js/src/**/*.js"></script>
      <!-- endfileblock -->
      <!-- endbuild -->

[D] Source file after processing.
[D]       <!-- fileblock:other reload -->
      <script src="//localhost:35729/livereload.js"></script>
      <!-- endfileblock -->

      <!-- build:js /assets/js/app.js -->
      <!-- fileblock:js scripts -->
      <script src="/assets/js/libs/a.lib.js"></script>
      <script src="/assets/js/libs/b.lib.js"></script>
      <script src="/assets/js/src/a.js"></script>
      <script src="/assets/js/src/b.js"></script>
      <!-- endfileblock -->
      <!-- endbuild -->
```

This pull request allows this. 
