### PR TITLE
config.templatesFn is optional, so should use an empty object by default

### DIFF
--- a/spec/fileprocessorspec.js
+++ b/spec/fileprocessorspec.js
@@ -23,7 +23,8 @@ var defaultConfig = {
         'css': '<link href="${file}" rel="stylesheet" />',
         'ref': '/// <reference path="${file}" />',
         'raw': '${file}'
-    }
+    },
+    templatesFn: {}
 };
 
 describe('FileProcessor on HTML file', function () {
@@ -85,7 +86,7 @@ describe('FileProcessor on HTML file', function () {
         //expect(processor.file.content).not.toMatch('localhost:35729');
     });
 
-    it("shoudl remove the block anchors if the removeAnchors option is true", function () {
+    it("should remove the block anchors if the removeAnchors option is true", function () {
         var blocks = processor.getBlocks(blockConfigs);
         var stylesBlock = _(blocks).find(function (b) {
             return b.name === 'styles';

--- a/tasks/fileblocks.js
+++ b/tasks/fileblocks.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
     /**
      * Normalize and return block configurations from the Gruntfile.
      * @param {Object[]|Object.<string, object>} blocks - The block configurations from the Gruntfile.
-     * @returns {BlockConfig[]} 
+     * @returns {BlockConfig[]}
      */
     var getConfigs = function (data, options) {
         var configs = [];
@@ -71,7 +71,8 @@ module.exports = function (grunt) {
                 'css': '<link href="${file}" rel="stylesheet" />',
                 'ref': '/// <reference path="${file}" />',
                 'raw': '${file}'
-            }
+            },
+            templateFn: {}
         };
 
         var options = _.merge(defaultOptions, this.options());
@@ -108,7 +109,7 @@ module.exports = function (grunt) {
                 } else {
                     block.updateFiles();
                 }
-                
+
                 processor.processBlock(block);
             });
 


### PR DESCRIPTION
The addition of the `config.templatesFn` option should be optional, but the `defaultConfig` does not specify it, causing an error at https://github.com/rrharvey/grunt-file-blocks/blob/d3e546b65df001ca6125237b8911f341b375771b/lib/fileprocessor.js#L90 when accessing the property.
